### PR TITLE
Rename `options` property to 'optionsList'

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ This component supports data-binding an array of String, an array of Objects as 
 
 ###Array of Strings
 
-Simply bind an array of strings to the 'options' attribute. The array values will be mapped to both 'value' and 'label'.
+Simply bind an array of strings to the 'options-list' attribute. The array values will be mapped to both 'value' and 'label'.
 
 ```
-<select is="select-with-options" options="{{options}}" value="{{value::change}}"></select>
+<select is="select-with-options" options-list="{{options}}" value="{{value::change}}"></select>
 ```
 
 ###Array of Objects
@@ -48,7 +48,7 @@ Simply bind an array of strings to the 'options' attribute. The array values wil
 If you supply an array of objects there are additional parameters to specify which object properties to map as the `value` and `label` (`option-value` and `option-label`).
 
 ```
-<select is="select-with-options" options="{{options}}" option-value="id" option-label="name" value="{{value::change}}"></select>
+<select is="select-with-options" options-list="{{options}}" option-value="id" option-label="name" value="{{value::change}}"></select>
 ```
 
 ###Hard coded options
@@ -56,7 +56,7 @@ If you supply an array of objects there are additional parameters to specify whi
 Just like a standard `select` element, you can provide hard-coded ```<option>``` tags, which are displayed before those provided in the `options` attribute.
 
 ```
-<select is="select-with-options" options="{{options}}" option-value="id" option-label="name" value="{{value::change}}">
+<select is="select-with-options" options-list="{{options}}" option-value="id" option-label="name" value="{{value::change}}">
     <option value="hardcoded_option">Hardcoded Option</option>
 </select>
 ```

--- a/demo.html
+++ b/demo.html
@@ -12,7 +12,7 @@
     <dom-module id="demo-1">
         <template>
             <div>
-                <select is="select-with-options" options="{{options}}" value="{{value::change}}">
+                <select is="select-with-options" options-list="{{options}}" value="{{value::change}}">
                 </select>
                 <span>{{value}}</span>
             </div>
@@ -41,7 +41,7 @@
     <dom-module id="demo-2">
         <template>
             <div>
-                <select is="select-with-options" options="{{options}}" option-value="id" option-label="name" value="{{value::change}}">
+                <select is="select-with-options" options-list="{{options}}" option-value="id" option-label="name" value="{{value::change}}">
                 </select>
                 <span>{{value}}</span>
             </div>
@@ -71,7 +71,7 @@
     <dom-module id="demo-3">
         <template>
             <div>
-                <select is="select-with-options" options="{{options}}" option-value="id" option-label="name" value="{{value::change}}">
+                <select is="select-with-options" options-list="{{options}}" option-value="id" option-label="name" value="{{value::change}}">
                     <option value="hardcoded_option">Hardcoded Option</option>
                 </select>
                 <span>{{value}}</span>

--- a/select-with-options.html
+++ b/select-with-options.html
@@ -1,5 +1,5 @@
 <script>
-    function createOption(parent, label, value ) {
+    function createOption(parent, label, value) {
         var option = document.createElement('option');
         option.textContent = label;
         option.value = value;
@@ -11,13 +11,13 @@
         is: 'select-with-options',
         extends: 'select',
         properties: {
-            options: { observer: '_renderOptions' },
+            optionsList: { observer: '_renderOptions' },
             optionValue: { type: String },
             optionLabel: { type: String }
         },
         _renderOptions: function() {
             var currentValue = this.value;
-            
+
             var baseOptions = [];
             while (this.firstChild) {
                 if (!this.firstChild.autoAdded) {
@@ -25,18 +25,16 @@
                 }
                 this.removeChild(this.firstChild);
             }
-            baseOptions.forEach( function( option ) {
-                this.appendChild( option );
-            }, this );
-            this.options.forEach( function( option ) {
+            baseOptions.forEach(function(option) {
+                this.appendChild(option);
+            }, this);
+            this.optionsList.forEach(function(option) {
                 var label = this.optionLabel ? option[this.optionLabel] : option;
                 var value = this.optionValue ? option[this.optionValue] : option;
-                createOption( this, label, value);
-            }, this );
+                createOption(this, label, value);
+            }, this);
 
             this.value = currentValue;
         }
     });
-
 </script>
-


### PR DESCRIPTION
Default 'options' property was overrided by the component property. That causes failures in scripts that expect default implementation of this property.
Also this causes issues in old Chrome versions (for example 38)
