### PR TITLE
Fix #8 - Dropdown not showing initial value when list is computed

### DIFF
--- a/demo-with-initial-value-and-computed-list.html
+++ b/demo-with-initial-value-and-computed-list.html
@@ -1,0 +1,58 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>select-with-options demo</title>
+</head>
+<body>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/0.7.21/webcomponents.min.js"></script>
+    <link rel="import" href="polymer.html">
+    <link rel="import" href="select-with-options.html">
+
+
+    <dom-module id="with-initial-value-and-computed-list">
+        <template>
+            <div>
+                <span> Initial value is '{{initialAirport}}'. It should be visible on load in the dropdown:</span>
+                <select value="{{airport::change}}" is="select-with-options" options-list="{{getAirportsForCity(city)}}" option-value="id" option-label="name">
+                    <option value="">Unspecified</option>
+                </select>
+                <span>Current value is '{{airport}}'.</span>
+            </div>
+        </template>
+    </dom-module>
+<script>
+    var initialAirport = 'LHR';
+    window.addEventListener('WebComponentsReady', function(e) {
+        new Polymer({
+            is: 'with-initial-value-and-computed-list',
+            properties: {
+                airport: {
+                    type: String,
+                    value: initialAirport
+                },
+                initialAirport: {
+                    type: String,
+                    value: initialAirport
+                },
+                city: {
+                    type: String,
+                    value: 'London'
+                }
+            },
+            getAirportsForCity: function (key) {
+                var airportsByCities = {
+                    'London': [
+                        { id: 'LHR', name: 'London Heathrow' },
+                        { id: 'LTN', name: 'Luton' },
+                    ],
+                };
+                return airportsByCities[key];
+            }
+        });
+    });
+</script>
+    <with-initial-value-and-computed-list></with-initial-value-and-computed-list>
+
+</body>
+</html>

--- a/demo-with-initial-value-and-computed-list.html
+++ b/demo-with-initial-value-and-computed-list.html
@@ -18,6 +18,7 @@
                     <option value="">Unspecified</option>
                 </select>
                 <span>Current value is '{{airport}}'.</span>
+                <button on-tap="changeValue">Change to 'LTN' using data-binding</button>
             </div>
         </template>
     </dom-module>
@@ -48,6 +49,9 @@
                     ],
                 };
                 return airportsByCities[key];
+            },
+            changeValue: function() {
+                this.set('value', 'LTN');
             }
         });
     });

--- a/select-with-options.html
+++ b/select-with-options.html
@@ -1,9 +1,11 @@
 <script>
-    function createOption(parent, label, value) {
+    function createOption(parent, label, value, selected) {
         var option = document.createElement('option');
         option.textContent = label;
         option.value = value;
         option.autoAdded = true;
+        if (selected)
+            option.setAttribute('selected', '');
         parent.appendChild(option);
     }
 
@@ -11,30 +13,46 @@
         is: 'select-with-options',
         extends: 'select',
         properties: {
-            optionsList: { observer: '_renderOptions' },
+            optionsList: { observer: '_optionsListChanged' },
             optionValue: { type: String },
             optionLabel: { type: String }
         },
-        _renderOptions: function() {
-            var currentValue = this.value;
+        attached: function () {
+            var currentValue = this._getValueString(this.value);
+            var baseOptions =
+                Polymer.dom(this.root).querySelectorAll('option')
+                    .filter(function (option) {
+                            return !option.autoAdded;
+                        })
+                    .forEach(function (option) {
+                            if (this._getValueString(option.getAttribute('value')) == currentValue)
+                                option.selected = true;
+                        }.bind(this));
+        },
+        _optionsListChanged: function(newOptionsList) {
+            var currentValue = this._getValueString(this.value);
 
-            var baseOptions = [];
-            while (this.firstChild) {
-                if (!this.firstChild.autoAdded) {
-                    baseOptions.push(this.firstChild);
-                }
-                this.removeChild(this.firstChild);
-            }
-            baseOptions.forEach(function(option) {
-                this.appendChild(option);
-            }, this);
-            this.optionsList.forEach(function(option) {
-                var label = this.optionLabel ? option[this.optionLabel] : option;
-                var value = this.optionValue ? option[this.optionValue] : option;
-                createOption(this, label, value);
-            }, this);
+            var newValueLabelPairs = newOptionsList.map(function (option) {
+                    return {
+                        value: this._getValueString(this.optionValue ? option[this.optionValue] : option),
+                        label: this.optionLabel ? option[this.optionLabel] : option
+                    };
+                }.bind(this));
 
-            this.value = currentValue;
+            Polymer.dom(this.root).querySelectorAll('option').filter(function (option) { return option.autoAdded; })
+                .forEach(function (option) {
+                    this.removeChild(option);
+                }.bind(this));
+
+            newValueLabelPairs.forEach(function (option) {
+                createOption(this, option.label, option.value, currentValue === option.value);
+            }, this);
+        },
+        _getValueString: function (val) {
+            if (val === null || val === undefined)
+                return '';
+            else
+                return val.toString();
         }
     });
 </script>

--- a/select-with-options.html
+++ b/select-with-options.html
@@ -15,7 +15,8 @@
         properties: {
             optionsList: { observer: '_optionsListChanged' },
             optionValue: { type: String },
-            optionLabel: { type: String }
+            optionLabel: { type: String },
+            keepValueWithNoMatchingOption: Boolean
         },
         attached: function () {
             var currentValue = this._getValueString(this.value);
@@ -41,6 +42,10 @@
 
             Polymer.dom(this.root).querySelectorAll('option').filter(function (option) { return option.autoAdded; })
                 .forEach(function (option) {
+                    if (!this.keepValueWithNoMatchingOption && option.selected && !newValueLabelPairs.filter(function(o) { return o.value === currentValue; })[0]) {
+                        this.set('value', '');
+                        this.fire('change'); // Needed so the uses of original <select value="prop::change"> have their prop updated too
+                    }
                     this.removeChild(option);
                 }.bind(this));
 

--- a/select-with-options.html
+++ b/select-with-options.html
@@ -16,19 +16,34 @@
             optionsList: { observer: '_optionsListChanged' },
             optionValue: { type: String },
             optionLabel: { type: String },
-            keepValueWithNoMatchingOption: Boolean
+            keepValueWithNoMatchingOption: Boolean,
+            value: { // Need to declare this property (thus overriding the native one) or else we don't receive changes from host's bound path
+                type: String,
+                observer: '_valueChanged',
+                notify: true
+            }
         },
-        attached: function () {
-            var currentValue = this._getValueString(this.value);
-            var baseOptions =
-                Polymer.dom(this.root).querySelectorAll('option')
-                    .filter(function (option) {
-                            return !option.autoAdded;
-                        })
-                    .forEach(function (option) {
-                            if (this._getValueString(option.getAttribute('value')) == currentValue)
-                                option.selected = true;
-                        }.bind(this));
+        ready: function () {
+            var currentlyInChange = false;
+            this.addEventListener('change', function () {
+                // After overriding 'value' property (which is needed, see above), the host's bound path in turn doesn't get updated when user interacts with the control.
+                // Using `this.set` and firing a 'change' event manually seem to fix it
+                if (this.selectedIndex >= 0) { // But need to use `selectedIndex`, since the this.value override for some reason does not fetch the value of the underlying native property but shows the unchanged option.
+                    this.set('value', Polymer.dom(this.root).querySelectorAll('option')[this.selectedIndex].value);
+                    try {
+                        if (currentlyInChange)
+                            return;
+                        currentlyInChange = true;
+                        this.fire('change'); 
+                    }
+                    finally {
+                        currentlyInChange = false;
+                    }
+                }
+            }.bind(this));
+        },
+        _valueChanged: function () {
+            this._updateSelectedOption();
         },
         _optionsListChanged: function(newOptionsList) {
             var currentValue = this._getValueString(this.value);
@@ -52,6 +67,16 @@
             newValueLabelPairs.forEach(function (option) {
                 createOption(this, option.label, option.value, currentValue === option.value);
             }, this);
+        },
+        _updateSelectedOption: function () {
+            var currentValue = this._getValueString(this.value);
+            var baseOptions =
+                Polymer.dom(this.root).querySelectorAll('option')
+                    .forEach(function (option) {
+                        if (this._getValueString(option.getAttribute('value')) == currentValue)
+                            option.selected = true;
+                    }.bind(this));
+
         },
         _getValueString: function (val) {
             if (val === null || val === undefined)


### PR DESCRIPTION
Hi @ssshake. Just found this issue in our project (see title).
See [reproduction](https://aqovia.github.io/polymer-select-with-options/with-initial-value-and-computed-list_data-binding-issue-bug.html).

Cause: When the options list is a computed, the value binding will get assigned before the options computation adds any options. This loses that value, because the native select's `.value` setter will change it to `''` when it can't find the option.

The original <select><template is=dom-repeat items=getAirportsForCity(city)></select> doesn't have the issue because templates are evaluated from leaves to roots.

See commit message of 'the fix commit' for details.

I've also added a solution to the remark I saw in https://github.com/vehikl/polymer-select-with-options/pull/4, one that states that the PR [_'Replaces a larger bug with a smaller one'_](https://github.com/vehikl/polymer-select-with-options/pull/4#issuecomment-238635923):
See commit message of the second small commit for details.